### PR TITLE
Dockerfiles: Reduce the image sizes and stack depth

### DIFF
--- a/Dockerfile.core16
+++ b/Dockerfile.core16
@@ -1,27 +1,25 @@
 FROM ubuntu:xenial
 
 # Grab dependencies
-RUN apt update
-RUN apt dist-upgrade --yes
-RUN apt install --yes curl sudo jq squashfs-tools locales
-RUN apt-mark auto curl jq squashfs-tools
+RUN apt update \
+    && apt dist-upgrade --yes \
+    && apt install --yes curl sudo jq squashfs-tools locales \
+    && apt-mark auto curl jq squashfs-tools \
+    && apt autoremove --yes \
+    && apt autoclean \
+    && apt clean
 
 # Grab the core snap from the stable channel, unpack it in the proper place, and then delete the snap
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
-RUN mkdir -p /snap/core
-RUN unsquashfs -d /snap/core/current core.snap
-RUN rm core.snap
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap \
+    && mkdir -p /snap/core \
+    && unsquashfs -d /snap/core/current core.snap \
+    && rm core.snap
 
 # Grab the snapcraft snap from the stable channel, unpack it in the proper place, and then delete the snap
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap
-RUN mkdir -p /snap/snapcraft
-RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
-RUN rm snapcraft.snap
-
-# Clean up
-RUN apt autoremove --yes
-RUN apt autoclean
-RUN apt clean
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap \
+    && mkdir -p /snap/snapcraft \
+    && unsquashfs -d /snap/snapcraft/current snapcraft.snap \
+    && rm snapcraft.snap
 
 COPY snapcraft-wrapper /snap/bin/snapcraft
 

--- a/Dockerfile.core18
+++ b/Dockerfile.core18
@@ -1,33 +1,31 @@
 FROM ubuntu:bionic
 
 # Grab dependencies
-RUN apt update
-RUN apt dist-upgrade --yes
-RUN apt install --yes curl sudo jq squashfs-tools locales
-RUN apt-mark auto curl jq squashfs-tools
+RUN apt update \
+    && apt dist-upgrade --yes \
+    && apt install --yes curl sudo jq squashfs-tools locales \
+    && apt-mark auto curl jq squashfs-tools \
+    && apt autoremove --yes \
+    && apt autoclean \
+    && apt clean
 
 # Grab the core snap from the stable channel, unpack it in the proper place, and then delete the snap
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap
-RUN mkdir -p /snap/core
-RUN unsquashfs -d /snap/core/current core.snap
-RUN rm core.snap
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core' | jq '.download_url' -r) --output core.snap \
+    && mkdir -p /snap/core \
+    && unsquashfs -d /snap/core/current core.snap \
+    && rm core.snap
 
 # Grab the core18 snap from the stable channel, unpack it in the proper place, and then delete the snap
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap
-RUN mkdir -p /snap/core18
-RUN unsquashfs -d /snap/core18/current core18.snap
-RUN rm core18.snap
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/core18' | jq '.download_url' -r) --output core18.snap \
+    && mkdir -p /snap/core18 \
+    && unsquashfs -d /snap/core18/current core18.snap \
+    && rm core18.snap
 
 # Grab the snapcraft snap from the stable channel, unpack it in the proper place, and then delete the snap
-RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap
-RUN mkdir -p /snap/snapcraft
-RUN unsquashfs -d /snap/snapcraft/current snapcraft.snap
-RUN rm snapcraft.snap
-
-# Clean up
-RUN apt autoremove --yes
-RUN apt autoclean
-RUN apt clean
+RUN curl -L $(curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/snapcraft?channel=stable' | jq '.download_url' -r) --output snapcraft.snap \
+    && mkdir -p /snap/snapcraft \
+    && unsquashfs -d /snap/snapcraft/current snapcraft.snap \
+    && rm snapcraft.snap
 
 COPY snapcraft-wrapper /snap/bin/snapcraft
 


### PR DESCRIPTION
- Reduce excessive use of `RUN`, which results in a deep image chain.
- Ensure each `RUN` is cleaned-up appropriately to reduce intermediate image sizes.

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>